### PR TITLE
fix: support option objects without hasOwnProperty

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const isNode = (el) => {
 }
 
 const has = (object, key) => {
-	return object.hasOwnProperty(key)
+	return Object.prototype.hasOwnProperty.call(object, key)
 }
 
 const mapObject = (object, fn) => {

--- a/test/index.js
+++ b/test/index.js
@@ -103,6 +103,15 @@ test('setting properties ignores prototype properties', (t) => {
 	t.is(checkbox.outerHTML, '<input name="yes" type="checkbox">')
 })
 
+test('setting properties works for objects without hasOwnProperty', (t) => {
+	const options = Object.create(null)
+	options.name = 'yes'
+	options.type = 'checkbox'
+
+	const checkbox = f('input', options)
+	t.is(checkbox.outerHTML, '<input name="yes" type="checkbox">')
+})
+
 test('registers event handlers', (t) => {
 	const onClick = spy()
 	const para = f('p', {


### PR DESCRIPTION
## Summary
- replace direct `object.hasOwnProperty(key)` calls with `Object.prototype.hasOwnProperty.call(object, key)`
- add a regression test for options objects created with `Object.create(null)`

## Why
`Object.create(null)` objects do not inherit `hasOwnProperty`, so direct calls throw. This makes valid option objects fail unexpectedly when passed into `f()`.

## Testing
- `npx ava test/index.js --match "*without hasOwnProperty*"`
  - ✅ 1 test passed

## Notes
- I used a targeted test run because the repo currently has an existing `.only()` in tests, so full-suite execution is already constrained.
